### PR TITLE
modules load dependencies on import and replaces `register_adapters`

### DIFF
--- a/python/microns-manual-proofreading-api/microns_manual_proofreading_api/config/__init__.py
+++ b/python/microns-manual-proofreading-api/microns_manual_proofreading_api/config/__init__.py
@@ -29,6 +29,16 @@ def register_externals(schema_name:str):
         config_utils.register_externals(external_stores)
 
 
+def register_adapters(schema_name:str, context=None):
+    """
+    Imports the adapters for a schema_name into the global namespace.
+    """
+    adapter_objects = config_mapping[SCHEMAS(schema_name)]["adapters"]
+    
+    if adapter_objects is not None:
+        config_utils.register_adapters(adapter_objects, context=context)
+
+
 def register_bases(schema_name:str, module):
     """
     Maps base classes to DataJoint tables.

--- a/python/microns-manual-proofreading/microns_manual_proofreading/minnie_manual_proofreading/minnie65_manual_proofreading.py
+++ b/python/microns-manual-proofreading/microns_manual_proofreading/minnie_manual_proofreading/minnie65_manual_proofreading.py
@@ -12,3 +12,4 @@ config.register_externals(schema_obj)
 
 schema = dj.schema(schema_obj.value)
 schema.spawn_missing_classes()
+schema.connection.dependencies.load()


### PR DESCRIPTION
changes
- modules will now load dependencies on import
- replaces `register_adapters` which was accidentally removed